### PR TITLE
Refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "bmp"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Sondre Lefsaker"]
 
 description = "Small library for reading and writing BMP images in Rust."
@@ -17,5 +17,4 @@ keywords = ["bmp", "image"]
 exclude = ["test"]
 
 [dependencies]
-byteorder = "0.3.5"
-
+byteorder = "0.3"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fn main() {
     let mut img = Image::new(256, 256);
 
     for (x, y) in img.coordinates() {
-        img.set_pixel(x, y, px!(x - y / 255, y - x / 255, x + y / 255));
+        img.set_pixel(x, y, px!(x, y, 200));
     }
     let _ = img.save("img.bmp");
 }

--- a/README.md
+++ b/README.md
@@ -5,17 +5,16 @@ rust-bmp
 [Full documentation](http://sondrele.github.io/rust-bmp/bmp/index.html)
 
 Small module for reading and writing bitmap images.
-Currently only 24-bit RGB BMP images are supported.
+See the documentation for the current status of BMP encoding and decoding support.
 
 Usage
 -----
-The library should be available on [crates.io](https://crates.io/crates/bmp),
-but updated versions of the crate might lag behind until 1.0.0 of Rust has been released.
+An updated version of the library should be available on [crates.io](https://crates.io/crates/bmp).
+Add the following to your `Cargo.toml` to get is a dependency.
 
-To ensure that the crate is up to date, add it as a git dependency to `Cargo.toml` in your project.
 ```toml
-[dependencies.bmp]
-git = "https://github.com/sondrele/rust-bmp"
+[dependencies]
+bmp = "*"
 ```
 ###Initializing
 Initialize a new image with the `new` function, by specifying `width` and `height`.

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,0 +1,273 @@
+extern crate byteorder;
+
+use byteorder::{LittleEndian, ReadBytesExt};
+
+use std::collections::BitVec;
+use std::convert::{From, AsRef};
+use std::error::Error;
+use std::fmt;
+use std::io::{self, Cursor, Read, Write, SeekFrom, Seek};
+
+use {BmpId, BmpHeader, BmpDibHeader, CompressionType, Image, Pixel};
+use BmpVersion::*;
+
+use self::BmpErrorKind::*;
+
+/// A result type, either containing an `Image` or a `BmpError`.
+pub type BmpResult<T> = Result<T, BmpError>;
+
+/// The different kinds of possible BMP errors.
+#[derive(Debug)]
+pub enum BmpErrorKind {
+    WrongMagicNumbers,
+    UnsupportedBitsPerPixel,
+    UnsupportedCompressionType,
+    UnsupportedBmpVersion,
+    Other,
+    BmpIoError(io::Error),
+    BmpByteorderError(byteorder::Error),
+}
+
+/// The error type returned if the decoding of an image from disk fails.
+#[derive(Debug)]
+pub struct BmpError {
+    pub kind: BmpErrorKind,
+    pub details: String,
+}
+
+impl BmpError {
+    fn new<T: AsRef<str>>(kind: BmpErrorKind, details: T) -> BmpError {
+        let description = match kind {
+            WrongMagicNumbers => "Wrong magic numbers",
+            UnsupportedBitsPerPixel => "Unsupported bits per pixel",
+            UnsupportedCompressionType => "Unsupported compression type",
+            UnsupportedBmpVersion => "Unsupported BMP version",
+            _ => "BMP Error",
+        };
+
+        BmpError {
+            kind: kind,
+            details: format!("{}: {}", description, details.as_ref())
+        }
+    }
+}
+
+impl fmt::Display for BmpError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            BmpIoError(ref error) => return error.fmt(fmt),
+            _ => write!(fmt, "{}", self.description())
+        }
+    }
+}
+
+impl From<io::Error> for BmpError {
+    fn from(err: io::Error) -> BmpError {
+        BmpError::new(BmpIoError(err), "Io Error")
+    }
+}
+
+impl From<byteorder::Error> for BmpError {
+    fn from(err: byteorder::Error) -> BmpError {
+        BmpError::new(BmpByteorderError(err), "Byteorder Error")
+    }
+}
+
+impl Error for BmpError {
+    fn description(&self) -> &str {
+        match self.kind {
+            BmpIoError(ref e) => Error::description(e),
+            BmpByteorderError(ref e) => Error::description(e),
+            _ => &self.details
+        }
+    }
+}
+
+pub fn decode_image(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<Image> {
+    let id = try!(read_bmp_id(bmp_data));
+    let header = try!(read_bmp_header(bmp_data));
+    let dib_header = try!(read_bmp_dib_header(bmp_data));
+
+    let color_palette = try!(read_color_palette(bmp_data, &dib_header));
+
+    let width = dib_header.width.abs() as u32;
+    let height = dib_header.height.abs() as u32;
+    let padding = width % 4;
+
+    let data = match color_palette {
+        Some(ref palette) => try!(
+            read_indexes(bmp_data.get_mut(), &palette, width as usize, height as usize,
+                         dib_header.bits_per_pixel, header.pixel_offset as usize)
+        ),
+        None => try!(
+            read_pixels(bmp_data, width, height, header.pixel_offset, padding as i64)
+        )
+    };
+
+    let image = Image {
+        magic: id,
+        header: header,
+        dib_header: dib_header,
+        color_palette: color_palette,
+        width: width,
+        height: height,
+        padding: padding,
+        data: data
+    };
+
+    Ok(image)
+}
+
+fn read_bmp_id(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<BmpId> {
+    let mut bm = [0, 0];
+    try!(bmp_data.read(&mut bm));
+
+    if bm == b"BM"[..] {
+        Ok(BmpId::new())
+    } else {
+        Err(BmpError::new(WrongMagicNumbers, format!("Expected [66, 77], but was {:?}", bm)))
+    }
+}
+
+fn read_bmp_header(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<BmpHeader> {
+    let header = BmpHeader {
+        file_size:    try!(bmp_data.read_u32::<LittleEndian>()),
+        creator1:     try!(bmp_data.read_u16::<LittleEndian>()),
+        creator2:     try!(bmp_data.read_u16::<LittleEndian>()),
+        pixel_offset: try!(bmp_data.read_u32::<LittleEndian>()),
+    };
+
+    Ok(header)
+}
+
+fn read_bmp_dib_header(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<BmpDibHeader> {
+    let dib_header = BmpDibHeader {
+        header_size:    try!(bmp_data.read_u32::<LittleEndian>()),
+        width:          try!(bmp_data.read_i32::<LittleEndian>()),
+        height:         try!(bmp_data.read_i32::<LittleEndian>()),
+        num_planes:     try!(bmp_data.read_u16::<LittleEndian>()),
+        bits_per_pixel: try!(bmp_data.read_u16::<LittleEndian>()),
+        compress_type:  try!(bmp_data.read_u32::<LittleEndian>()),
+        data_size:      try!(bmp_data.read_u32::<LittleEndian>()),
+        hres:           try!(bmp_data.read_i32::<LittleEndian>()),
+        vres:           try!(bmp_data.read_i32::<LittleEndian>()),
+        num_colors:     try!(bmp_data.read_u32::<LittleEndian>()),
+        num_imp_colors: try!(bmp_data.read_u32::<LittleEndian>()),
+    };
+
+    match dib_header.header_size {
+        // BMPv2 has a header size of 12 bytes
+        12 => return Err(BmpError::new(UnsupportedBmpVersion, Version2)),
+        // BMPv3 has a header size of 40 bytes, it is NT if the compression type is 3
+        40 if dib_header.compress_type == 3 =>
+            return Err(BmpError::new(UnsupportedBmpVersion, Version3NT)),
+        // BMPv4 has more data in its header, it is currently ignored but we still try to parse it
+        108 | _ => ()
+    }
+
+    match dib_header.bits_per_pixel {
+        // Currently supported
+        1 | 4 | 8 | 24 => (),
+        other => return Err(
+            BmpError::new(UnsupportedBitsPerPixel, format!("{}", other))
+        )
+    }
+
+    match CompressionType::from_u32(dib_header.compress_type) {
+        CompressionType::Uncompressed => (),
+        other => return Err(BmpError::new(UnsupportedCompressionType, other)),
+    }
+
+    Ok(dib_header)
+}
+
+fn read_color_palette(bmp_data: &mut Cursor<Vec<u8>>, dh: &BmpDibHeader) ->
+                      BmpResult<Option<Vec<Pixel>>> {
+    let num_entries = match dh.bits_per_pixel {
+        // We have a color_palette if there if num_colors in the dib header is not zero
+        _ if dh.num_colors != 0 => dh.num_colors as usize,
+        // Or if there are 8 or less bits per pixel
+        bpp @ 1 | bpp @ 4 | bpp @ 8 => 1 << bpp,
+        _ => return Ok(None)
+    };
+
+    let num_bytes = match dh.header_size {
+        // Each entry in the color_palette is four bytes for Version 3 or 4
+        40 | 108 => 4,
+        // Three bytes for Version two. Though, this is currently not supported
+        _ => return Err(BmpError::new(UnsupportedBmpVersion, Version2))
+    };
+
+    let mut px = &mut [0; 4][0 .. num_bytes as usize];
+    let mut color_palette = Vec::with_capacity(num_entries);
+    for _ in 0 .. num_entries {
+        try!(bmp_data.read(&mut px));
+        color_palette.push(px!(px[2], px[1], px[0]));
+    }
+
+    Ok(Some(color_palette))
+}
+
+fn read_indexes(bmp_data: &mut Vec<u8>, palette: &Vec<Pixel>,
+                width: usize, height: usize, bpp: u16, offset: usize) -> BmpResult<Vec<Pixel>> {
+    let mut data = Vec::with_capacity(height * width);
+    // Number of bytes to read from each row, varies based on bits_per_pixel
+    let bytes_per_row = (width as f64 / (8.0 / bpp as f64)).ceil() as usize;
+    for y in 0 .. height {
+        let padding = match bytes_per_row % 4 {
+            0 => 0,
+            other => 4 - other
+        };
+        let start = offset + (bytes_per_row + padding) * y;
+        let bytes = &bmp_data[start .. start + bytes_per_row];
+
+        // determine how to parse each row, depending on bits_per_pixel
+        match bpp {
+            1 => {
+                let bits = BitVec::from_bytes(&bytes[..]);
+                for b in 0 .. width as usize {
+                    match bits[b] {
+                        true => data.push(palette[1]),
+                        false => data.push(palette[0])
+                    }
+                }
+            },
+            4 => {
+                let mut index = Vec::with_capacity(data.len() + 1);
+                for b in bytes {
+                    index.push((b >> 4));
+                    index.push((b & 0x0f));
+                }
+                for i in 0 .. width as usize {
+                    data.push(palette[index[i] as usize]);
+                }
+            },
+            8 => {
+                for index in bytes {
+                    data.push(palette[*index as usize]);
+                }
+            },
+            other => return Err(BmpError::new(Other,
+                format!("BMP does not support color palettes for {} bits per pixel", other)))
+        }
+    }
+    Ok(data)
+}
+
+fn read_pixels(bmp_data: &mut Cursor<Vec<u8>>, width: u32, height: u32,
+               offset: u32, padding: i64) -> BmpResult<Vec<Pixel>> {
+    let mut data = Vec::with_capacity((height * width) as usize);
+    // seek until data
+    try!(bmp_data.seek(SeekFrom::Start(offset as u64)));
+    // read pixels until padding
+    let mut px = [0; 3];
+    for _ in 0 .. height {
+        for _ in 0 .. width {
+            try!(bmp_data.read(&mut px));
+            data.push(px!(px[2], px[1], px[0]));
+        }
+        // seek padding
+        try!(bmp_data.seek(SeekFrom::Current(padding)));
+    }
+    Ok(data)
+}

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -8,7 +8,7 @@ use std::error::Error;
 use std::fmt;
 use std::io::{self, Cursor, Read, Write, SeekFrom, Seek};
 
-use {BmpId, BmpHeader, BmpDibHeader, CompressionType, Image, Pixel};
+use {BmpHeader, BmpDibHeader, CompressionType, Image, Pixel};
 use BmpVersion::*;
 
 use self::BmpErrorKind::*;
@@ -84,7 +84,7 @@ impl Error for BmpError {
 }
 
 pub fn decode_image(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<Image> {
-    let id = try!(read_bmp_id(bmp_data));
+    try!(read_bmp_id(bmp_data));
     let header = try!(read_bmp_header(bmp_data));
     let dib_header = try!(read_bmp_dib_header(bmp_data));
 
@@ -105,7 +105,6 @@ pub fn decode_image(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<Image> {
     };
 
     let image = Image {
-        magic: id,
         header: header,
         dib_header: dib_header,
         color_palette: color_palette,
@@ -118,12 +117,12 @@ pub fn decode_image(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<Image> {
     Ok(image)
 }
 
-fn read_bmp_id(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<BmpId> {
+fn read_bmp_id(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<()> {
     let mut bm = [0, 0];
     try!(bmp_data.read(&mut bm));
 
     if bm == b"BM"[..] {
-        Ok(BmpId::new())
+        Ok(())
     } else {
         Err(BmpError::new(WrongMagicNumbers, format!("Expected [66, 77], but was {:?}", bm)))
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,0 +1,56 @@
+extern crate byteorder;
+use byteorder::{LittleEndian, WriteBytesExt};
+
+use std::io::{self, Write};
+
+use Image;
+
+const B: u8 = 66;
+const M: u8 = 77;
+
+pub fn encode_image(bmp_image: &Image) -> io::Result<Vec<u8>> {
+    let mut bmp_data = Vec::with_capacity(bmp_image.header.file_size as usize);
+
+    try!(write_header(&mut bmp_data, bmp_image));
+    try!(write_data(&mut bmp_data, bmp_image));
+    Ok(bmp_data)
+}
+
+fn write_header(bmp_data: &mut Vec<u8>, img: &Image) -> io::Result<()> {
+    let header = &img.header;
+    let dib_header = &img.dib_header;
+    let (header_size, data_size) = file_size!(24, img.width, img.height);
+
+    try!(io::Write::write(bmp_data, &[B, M]));
+
+    try!(bmp_data.write_u32::<LittleEndian>(header_size + data_size));
+    try!(bmp_data.write_u16::<LittleEndian>(header.creator1));
+    try!(bmp_data.write_u16::<LittleEndian>(header.creator2));
+    try!(bmp_data.write_u32::<LittleEndian>(header_size)); // pixel_offset
+
+    try!(bmp_data.write_u32::<LittleEndian>(dib_header.header_size));
+    try!(bmp_data.write_i32::<LittleEndian>(dib_header.width));
+    try!(bmp_data.write_i32::<LittleEndian>(dib_header.height));
+    try!(bmp_data.write_u16::<LittleEndian>(1));  // num_planes
+    try!(bmp_data.write_u16::<LittleEndian>(24)); // bits_per_pixel
+    try!(bmp_data.write_u32::<LittleEndian>(0));  // compress_type
+    try!(bmp_data.write_u32::<LittleEndian>(data_size));
+    try!(bmp_data.write_i32::<LittleEndian>(dib_header.hres));
+    try!(bmp_data.write_i32::<LittleEndian>(dib_header.vres));
+    try!(bmp_data.write_u32::<LittleEndian>(0)); // num_colors
+    try!(bmp_data.write_u32::<LittleEndian>(0)); // num_imp_colors
+    Ok(())
+}
+
+fn write_data(bmp_data: &mut Vec<u8>, img: &Image) -> io::Result<()> {
+    let padding = &[0; 4][0 .. img.padding as usize];
+    for y in 0 .. img.height {
+        for x in 0 .. img.width {
+            let index = (y * img.width + x) as usize;
+            let px = &img.data[index];
+            try!(Write::write(bmp_data, &[px.b, px.g, px.r]));
+        }
+        try!(Write::write(bmp_data, padding));
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!     let mut img = Image::new(256, 256);
 //!
 //!     for (x, y) in img.coordinates() {
-//!         img.set_pixel(x, y, px!(x, y, x));
+//!         img.set_pixel(x, y, px!(x, y, 200));
 //!     }
 //!     let _ = img.save("img.bmp");
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![crate_type = "lib"]
 #![warn(warnings)]
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(test, feature(path_ext))]
@@ -10,10 +9,10 @@
 //!
 //! |Scheme | Decoding | Encoding | Compression |
 //! |-------|----------|----------|-------------|
-//! | 24 bpp| ✓        | ✓       | No
-//! | 8 bpp | ✓        | ✗       | No
-//! | 4 bpp | ✓        | ✗       | No
-//! | 1 bpp | ✓        | ✗       | No
+//! | 24 bpp| ✓        | ✓        | No          |
+//! | 8 bpp | ✓        | ✗        | No          |
+//! | 4 bpp | ✓        | ✗        | No          |
+//! | 1 bpp | ✓        | ✗        | No          |
 //!
 //! # Example
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![crate_type = "lib"]
 #![warn(warnings)]
-#![feature(collections)]
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(test, feature(path_ext))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,20 +35,20 @@
 //!
 
 extern crate byteorder;
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian, WriteBytesExt};
 
-use std::collections::BitVec;
-use std::convert::{From, AsRef};
+use std::convert::{AsRef};
 use std::error::Error;
 use std::fmt;
 use std::fs;
 use std::io;
-use std::io::{Cursor, Read, Write, SeekFrom, Seek};
+use std::io::{Cursor, Read, Write};
 use std::iter::Iterator;
 
 use ::CompressionType::*;
-use ::BmpErrorKind::*;
 use ::BmpVersion::*;
+
+pub use decoder::{BmpError, BmpErrorKind, BmpResult};
 
 #[cfg(test)]
 mod tests;
@@ -77,75 +77,7 @@ macro_rules! px {
 /// Common color constants accessible by names.
 pub mod consts;
 
-/// A result type, either containing an `Image` or a `BmpError`.
-pub type BmpResult<T> = Result<T, BmpError>;
-
-/// The different kinds of possible BMP errors.
-#[derive(Debug)]
-pub enum BmpErrorKind {
-    WrongMagicNumbers,
-    UnsupportedBitsPerPixel,
-    UnsupportedCompressionType,
-    UnsupportedBmpVersion,
-    Other,
-    BmpIoError(io::Error),
-    BmpByteorderError(byteorder::Error),
-}
-
-/// The error type returned if the decoding of an image from disk fails.
-#[derive(Debug)]
-pub struct BmpError {
-    pub kind: BmpErrorKind,
-    pub details: String,
-}
-
-impl BmpError {
-    fn new<T: AsRef<str>>(kind: BmpErrorKind, details: T) -> BmpError {
-        let description = match kind {
-            WrongMagicNumbers => "Wrong magic numbers",
-            UnsupportedBitsPerPixel => "Unsupported bits per pixel",
-            UnsupportedCompressionType => "Unsupported compression type",
-            UnsupportedBmpVersion => "Unsupported BMP version",
-            _ => "BMP Error",
-        };
-
-        BmpError {
-            kind: kind,
-            details: format!("{}: {}", description, details.as_ref())
-        }
-    }
-}
-
-impl fmt::Display for BmpError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self.kind {
-            BmpIoError(ref error) => return error.fmt(fmt),
-            _ => write!(fmt, "{}", self.description())
-        }
-    }
-}
-
-impl From<io::Error> for BmpError {
-    fn from(err: io::Error) -> BmpError {
-        BmpError::new(BmpIoError(err), "Io Error")
-    }
-}
-
-impl From<byteorder::Error> for BmpError {
-    fn from(err: byteorder::Error) -> BmpError {
-        BmpError::new(BmpByteorderError(err), "Byteorder Error")
-    }
-}
-
-impl Error for BmpError {
-    fn description(&self) -> &str {
-        match self.kind {
-            BmpIoError(ref e) => Error::description(e),
-            BmpByteorderError(ref e) => Error::description(e),
-            _ => &self.details
-        }
-    }
-}
+mod decoder;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum BmpVersion {
@@ -484,192 +416,7 @@ pub fn open(name: &str) -> BmpResult<Image> {
     try!(f.read_to_end(&mut bytes));
     let mut bmp_data = Cursor::new(bytes);
 
-    let id = try!(read_bmp_id(&mut bmp_data));
-    let header = try!(read_bmp_header(&mut bmp_data));
-    let dib_header = try!(read_bmp_dib_header(&mut bmp_data));
-
-    let color_palette = try!(read_color_palette(&mut bmp_data, &dib_header));
-
-    let width = dib_header.width.abs() as u32;
-    let height = dib_header.height.abs() as u32;
-    let padding = width % 4;
-
-    let data = match color_palette {
-        Some(ref palette) => try!(
-            read_indexes(&mut bmp_data.into_inner(), &palette, width as usize, height as usize,
-                         dib_header.bits_per_pixel, header.pixel_offset as usize)
-        ),
-        None => try!(
-            read_pixels(&mut bmp_data, width, height, header.pixel_offset, padding as i64)
-        )
-    };
-
-    let image = Image {
-        magic: id,
-        header: header,
-        dib_header: dib_header,
-        color_palette: color_palette,
-        width: width,
-        height: height,
-        padding: padding,
-        data: data
-    };
-
-    Ok(image)
-}
-
-fn read_bmp_id(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<BmpId> {
-    let mut bm = [0, 0];
-    try!(bmp_data.read(&mut bm));
-
-    if bm == b"BM"[..] {
-        Ok(BmpId::new())
-    } else {
-        Err(BmpError::new(WrongMagicNumbers, format!("Expected [66, 77], but was {:?}", bm)))
-    }
-}
-
-fn read_bmp_header(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<BmpHeader> {
-    let header = BmpHeader {
-        file_size:    try!(bmp_data.read_u32::<LittleEndian>()),
-        creator1:     try!(bmp_data.read_u16::<LittleEndian>()),
-        creator2:     try!(bmp_data.read_u16::<LittleEndian>()),
-        pixel_offset: try!(bmp_data.read_u32::<LittleEndian>()),
-    };
-
-    Ok(header)
-}
-
-fn read_bmp_dib_header(bmp_data: &mut Cursor<Vec<u8>>) -> BmpResult<BmpDibHeader> {
-    let dib_header = BmpDibHeader {
-        header_size:    try!(bmp_data.read_u32::<LittleEndian>()),
-        width:          try!(bmp_data.read_i32::<LittleEndian>()),
-        height:         try!(bmp_data.read_i32::<LittleEndian>()),
-        num_planes:     try!(bmp_data.read_u16::<LittleEndian>()),
-        bits_per_pixel: try!(bmp_data.read_u16::<LittleEndian>()),
-        compress_type:  try!(bmp_data.read_u32::<LittleEndian>()),
-        data_size:      try!(bmp_data.read_u32::<LittleEndian>()),
-        hres:           try!(bmp_data.read_i32::<LittleEndian>()),
-        vres:           try!(bmp_data.read_i32::<LittleEndian>()),
-        num_colors:     try!(bmp_data.read_u32::<LittleEndian>()),
-        num_imp_colors: try!(bmp_data.read_u32::<LittleEndian>()),
-    };
-
-    match dib_header.header_size {
-        // BMPv2 has a header size of 12 bytes
-        12 => return Err(BmpError::new(UnsupportedBmpVersion, Version2)),
-        // BMPv3 has a header size of 40 bytes, it is NT if the compression type is 3
-        40 if dib_header.compress_type == 3 =>
-            return Err(BmpError::new(UnsupportedBmpVersion, Version3NT)),
-        // BMPv4 has more data in its header, it is currently ignored but we still try to parse it
-        108 | _ => ()
-    }
-
-    match dib_header.bits_per_pixel {
-        // Currently supported
-        1 | 4 | 8 | 24 => (),
-        other => return Err(
-            BmpError::new(UnsupportedBitsPerPixel, format!("{}", other))
-        )
-    }
-
-    match CompressionType::from_u32(dib_header.compress_type) {
-        Uncompressed => (),
-        other => return Err(BmpError::new(UnsupportedCompressionType, other)),
-    }
-
-    Ok(dib_header)
-}
-
-fn read_color_palette(bmp_data: &mut Cursor<Vec<u8>>, dh: &BmpDibHeader) ->
-                      BmpResult<Option<Vec<Pixel>>> {
-    let num_entries = match dh.bits_per_pixel {
-        // We have a color_palette if there if num_colors in the dib header is not zero
-        _ if dh.num_colors != 0 => dh.num_colors as usize,
-        // Or if there are 8 or less bits per pixel
-        bpp @ 1 | bpp @ 4 | bpp @ 8 => 1 << bpp,
-        _ => return Ok(None)
-    };
-
-    let num_bytes = match dh.header_size {
-        // Each entry in the color_palette is four bytes for Version 3 or 4
-        40 | 108 => 4,
-        // Three bytes for Version two. Though, this is currently not supported
-        _ => return Err(BmpError::new(UnsupportedBmpVersion, Version2))
-    };
-
-    let mut px = &mut [0; 4][0 .. num_bytes as usize];
-    let mut color_palette = Vec::with_capacity(num_entries);
-    for _ in 0 .. num_entries {
-        try!(bmp_data.read(&mut px));
-        color_palette.push(px!(px[2], px[1], px[0]));
-    }
-
-    Ok(Some(color_palette))
-}
-
-fn read_indexes(bmp_data: &mut Vec<u8>, palette: &Vec<Pixel>,
-                width: usize, height: usize, bpp: u16, offset: usize) -> BmpResult<Vec<Pixel>> {
-    let mut data = Vec::with_capacity(height * width);
-    // Number of bytes to read from each row, varies based on bits_per_pixel
-    let bytes_per_row = (width as f64 / (8.0 / bpp as f64)).ceil() as usize;
-    for y in 0 .. height {
-        let padding = match bytes_per_row % 4 {
-            0 => 0,
-            other => 4 - other
-        };
-        let start = offset + (bytes_per_row + padding) * y;
-        let bytes = &bmp_data[start .. start + bytes_per_row];
-
-        // determine how to parse each row, depending on bits_per_pixel
-        match bpp {
-            1 => {
-                let bits = BitVec::from_bytes(&bytes[..]);
-                for b in 0 .. width as usize {
-                    match bits[b] {
-                        true => data.push(palette[1]),
-                        false => data.push(palette[0])
-                    }
-                }
-            },
-            4 => {
-                let mut index = Vec::with_capacity(data.len() + 1);
-                for b in bytes {
-                    index.push((b >> 4));
-                    index.push((b & 0x0f));
-                }
-                for i in 0 .. width as usize {
-                    data.push(palette[index[i] as usize]);
-                }
-            },
-            8 => {
-                for index in bytes {
-                    data.push(palette[*index as usize]);
-                }
-            },
-            other => return Err(BmpError::new(Other,
-                format!("BMP does not support color palettes for {} bits per pixel", other)))
-        }
-    }
-    Ok(data)
-}
-
-fn read_pixels(bmp_data: &mut Cursor<Vec<u8>>, width: u32, height: u32,
-               offset: u32, padding: i64) -> BmpResult<Vec<Pixel>> {
-    let mut data = Vec::with_capacity((height * width) as usize);
-    // seek until data
-    try!(bmp_data.seek(SeekFrom::Start(offset as u64)));
-    // read pixels until padding
-    let mut px = [0; 3];
-    for _ in 0 .. height {
-        for _ in 0 .. width {
-            try!(bmp_data.read(&mut px));
-            data.push(px!(px[2], px[1], px[0]));
-        }
-        // seek padding
-        try!(bmp_data.seek(SeekFrom::Current(padding)));
-    }
-    Ok(data)
+    decoder::decode_image(&mut bmp_data)
 }
 
 /// An `Iterator` returning the `x` and `y` coordinates of an image.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,6 @@ pub use decoder::{BmpError, BmpErrorKind, BmpResult};
 #[cfg(test)]
 mod tests;
 
-const B: u8 = 66;
-const M: u8 = 77;
-
 /// The pixel data used in the `Image`.
 ///
 /// It has three values for the `red`, `blue` and `green` color channels, respectively.
@@ -140,21 +137,6 @@ impl AsRef<str> for CompressionType {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct BmpId {
-    magic1: u8,
-    magic2: u8
-}
-
-impl BmpId {
-    pub fn new() -> BmpId {
-        BmpId {
-            magic1: B,
-            magic2: M
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
 struct BmpHeader {
     file_size: u32,
     creator1: u16,
@@ -220,7 +202,6 @@ impl BmpDibHeader {
 /// Currently, only uncompressed BMP images are supported.
 #[derive(Clone, Eq, PartialEq)]
 pub struct Image {
-    magic: BmpId,
     header: BmpHeader,
     dib_header: BmpDibHeader,
     color_palette: Option<Vec<Pixel>>,
@@ -233,7 +214,6 @@ pub struct Image {
 impl fmt::Debug for Image {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         try!(write!(f, "Image {}\n", '{'));
-        try!(write!(f, "\tmagic: {:?},\n", self.magic));
         try!(write!(f, "\theader: {:?},\n", self.header));
         try!(write!(f, "\tdib_header: {:?},\n", self.dib_header));
         try!(write!(f, "\tcolor_palette: {:?},\n", self.color_palette));
@@ -263,7 +243,6 @@ impl Image {
 
         let (header_size, data_size) = file_size!(24, width, height);
         Image {
-            magic: BmpId::new(),
             header: BmpHeader::new(header_size, data_size),
             dib_header: BmpDibHeader::new(width as i32, height as i32),
             color_palette: None,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -6,16 +6,14 @@ use std::io::{Read, Seek, SeekFrom};
 use std::mem::size_of;
 use std::path;
 
-use {open, BmpError, BmpErrorKind, BmpId, BmpHeader, BmpDibHeader, Image, Pixel};
+use {open, BmpError, BmpErrorKind, BmpHeader, BmpDibHeader, Image, Pixel};
 use consts;
 
 #[test]
 fn size_of_bmp_header_is_54_bytes() {
-    let bmp_magic_size = size_of::<BmpId>();
     let bmp_header_size = size_of::<BmpHeader>();
     let bmp_bip_header_size = size_of::<BmpDibHeader>();
 
-    assert_eq!(2,  bmp_magic_size);
     assert_eq!(12, bmp_header_size);
     assert_eq!(40, bmp_bip_header_size);
 }
@@ -36,18 +34,18 @@ fn verify_test_bmp_image(img: Image) {
     assert_eq!(0,  header.creator2);
 
     let dib_header = img.dib_header;
-    assert_eq!(54, header.pixel_offset);
-    assert_eq!(40,    dib_header.header_size);
-    assert_eq!(2,     dib_header.width);
-    assert_eq!(2,     dib_header.height);
-    assert_eq!(1,     dib_header.num_planes);
-    assert_eq!(24,    dib_header.bits_per_pixel);
-    assert_eq!(0,     dib_header.compress_type);
-    assert_eq!(16,    dib_header.data_size);
+    assert_eq!(54,   header.pixel_offset);
+    assert_eq!(40,   dib_header.header_size);
+    assert_eq!(2,    dib_header.width);
+    assert_eq!(2,    dib_header.height);
+    assert_eq!(1,    dib_header.num_planes);
+    assert_eq!(24,   dib_header.bits_per_pixel);
+    assert_eq!(0,    dib_header.compress_type);
+    assert_eq!(16,   dib_header.data_size);
     assert_eq!(1000, dib_header.hres);
     assert_eq!(1000, dib_header.vres);
-    assert_eq!(0,     dib_header.num_colors);
-    assert_eq!(0,     dib_header.num_imp_colors);
+    assert_eq!(0,    dib_header.num_colors);
+    assert_eq!(0,    dib_header.num_imp_colors);
 
     assert_eq!(2, img.padding);
 }


### PR DESCRIPTION
Refactoring.
* Moved encoding/decoding of images into its own modules
* Added a custom iterator for calculating indexes into color palette when decoding. The library no longer depends on `collections`
* Fix example in readme
