### PR TITLE
Update the byteorder library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ keywords = ["bmp", "image"]
 exclude = ["test"]
 
 [dependencies]
-byteorder = "0.5.3"
+byteorder = "^1.0.0"


### PR DESCRIPTION
I think it's a good idea to update to byteorder version 1.0. This pull request changes the required version of the library to ^1.0.0, i.e. at least 1.0. 