### PR TITLE
Add fmt methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,27 @@ impl Pixel {
     }
 }
 
+/// Displays the rgb values as an rgb color triple
+impl fmt::Display for Pixel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "rgb({}, {}, {})", self.r, self.g, self.b)
+    }
+}
+
+/// Displays the rgb values as an upper-case 24-bit hexadecimal number
+impl fmt::UpperHex for Pixel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:02X}{:02X}{:02X}", self.r, self.g, self.b)
+    }
+}
+
+/// Displays the rgb values as a lower-case 24-bit hexadecimal number
+impl fmt::LowerHex for Pixel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:02x}{:02x}{:02x}", self.r, self.g, self.b)
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum BmpVersion {
     Two,


### PR DESCRIPTION
While using your library for one of my projects, I was saddened to see that you hadn't implemented any formatters for the `Pixel` struct. So I went ahead and did that for you.

It made debugging easier (for me) to be able to see the colours as `#abcdef` rather than `Pixel { r: 171, g: 205, b: 239 }` and I'm thinking I'm not alone in this thinking.

This simple pull request adds `{}`, `{:x}` and `{:X}` to the formatter.