### PR TITLE
Bounds checks for `Image::get_pixel` and `Image::set_pixel`

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -39,7 +39,7 @@ impl fmt::Display for BmpError {
             BmpIoError(ref error) => error.fmt(fmt),
             ref e => {
                 let kind_desc: &str = e.as_ref();
-                write!(fmt, "{}: {}", kind_desc, self.description())
+                write!(fmt, "{}: {}", kind_desc, self)
             }
         }
     }
@@ -51,14 +51,7 @@ impl From<io::Error> for BmpError {
     }
 }
 
-impl Error for BmpError {
-    fn description(&self) -> &str {
-        match self.kind {
-            BmpIoError(ref e) => e.description(),
-            _ => &self.details,
-        }
-    }
-}
+impl Error for BmpError {}
 
 /// The different kinds of possible BMP errors.
 #[derive(Debug)]
@@ -299,7 +292,7 @@ struct BitIndex<'a> {
     index: usize,
 }
 
-fn bit_index<'a>(bytes: &'a [u8], nbits: usize, size: usize) -> BitIndex {
+fn bit_index<'a>(bytes: &'a [u8], nbits: usize, size: usize) -> BitIndex<'a> {
     let bits_left = BITS - nbits;
     BitIndex {
         size,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,35 @@ impl Image {
         self.height
     }
 
+    /// Checks that the provided coordinate `(x, y)` is within bounds for the image.
+    ///
+    /// # Panics
+    /// 
+    /// - This function will panic when the index is out of bounds, providing a descriptive error
+    /// message.
+    fn check_index_validity(&self, x: u32, y: u32) {
+        match (x >= self.width, y >= self.height) {
+            (true, true) =>
+                panic!(concat!(
+                    "index out of bounds: the width and height are {} and {} respectively,",
+                    " but the coordinate is ({}, {})"),
+                    self.width, self.height,
+                    x, y,
+                ),
+            (true, false) =>
+                panic!(
+                    "index out of bounds: the width is {} but the x coordinate is {}",
+                    self.width, x,
+                ),
+            (false, true) =>
+                panic!(
+                    "index out of bounds: the height is {} but the y coordinate is {}",
+                    self.height, y,
+                ),
+            _ =>(),
+        }
+    }
+
     /// Set the pixel value at the position of `width` and `height`.
     ///
     /// # Example
@@ -292,6 +321,7 @@ impl Image {
     /// ```
     #[inline]
     pub fn set_pixel(&mut self, x: u32, y: u32, val: Pixel) {
+        self.check_index_validity(x, y);
         self.data[((self.height - y - 1) * self.width + x) as usize] = val;
     }
 
@@ -305,6 +335,7 @@ impl Image {
     /// ```
     #[inline]
     pub fn get_pixel(&self, x: u32, y: u32) -> Pixel {
+        self.check_index_validity(x, y);
         self.data[((self.height - y - 1) * self.width + x) as usize]
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,6 +665,44 @@ mod tests {
         assert_eq!(coords.next(), Some((1, 2)));
     }
 
+    #[test]
+    fn coordinates_in_bounds() {
+        // This is to test for false positives in oout of bounds checks
+        let img = Image::new(20, 30);
+        for (x, y) in img.coordinates() {
+            img.check_index_validity(x, y);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn out_of_bounds_1() {
+        let img = Image::new(20, 30);
+        img.get_pixel(20, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn out_of_bounds_2() {
+        let img = Image::new(20, 30);
+        img.get_pixel(0, 30);
+    }
+
+    #[test]
+    #[should_panic]
+    fn out_of_bounds_3() {
+        let img = Image::new(20, 30);
+        img.get_pixel(20, 30);
+    }
+
+    #[test]
+    #[should_panic]
+    fn out_of_bounds_4() {
+        let img = Image::new(20, 30);
+        img.get_pixel(100, 100);
+    }
+
+
     // TODO: Add benches when they are considered stable
     // #[bench]
     // fn write_bmp(b: &mut test::Bencher) {


### PR DESCRIPTION
This PR adds index out of bounds checks for `Image::get_pixel` and `Image::set_pixel`, resolving a class of similar errors.

For instance, `bmp::Image::new(20, 20).get_pixel(20, 0)` currently results in an internal index out of bounds error, which is somewhat confusing for the user of the library, while `bmp::Image::new(20, 20).get_pixel(0, 20)`  for instance results in a subtract with overflow on debug mode or an index of `4294967276` out of bounds in release mode.

Because `bmp::Image::new(20, 20).get_pixel(20, 20)` will, on release mode, not panic at all in the existing code (just silently give an unexpected result), this change ought to be considered breaking.

I also updated some other small parts of the library since it looks like this crate hasn't been updated since a few changes to the Rust language and standard library.